### PR TITLE
Einige Anpassungen, die ich brauchte:

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1,3 +1,8 @@
 <?php
 
+if (class_exists(rex_fragment::class)) {
+	rex_fragment::addDirectory(realpath(__DIR__));
+}
+
 rex_extension::register('MEDIA_ADDED', ['rex_mediapool_exif', 'processUploadedMedia'], rex_extension::LATE );
+rex_extension::register('MEDIA_DETAIL_SIDEBAR', ['rex_mediapool_exif', 'mediapoolDetailOutput']);

--- a/fragments/mediapool_sidebar.php
+++ b/fragments/mediapool_sidebar.php
@@ -1,0 +1,25 @@
+<?php
+$collapse_id = 'collapse-'.random_int(100000, 999999);
+
+$attributes = [];
+$attributes['class'][] = 'panel-heading';
+if ($this->collapsed) {
+	$attributes['class'][] = 'collapsed';
+}
+$attributes['data-toggle'] = 'collapse';
+$attributes['data-target'] = '#'.$collapse_id;
+?>
+
+<br />
+<div id="rex-js-main-sidebar">
+	<section class="rex-page-section">
+		<div class="panel panel-default">
+			<header <?= rex_string::buildAttributes($attributes); ?>><div class="panel-title"><i class="rex-icon rex-icon-info"></i> <?= $this->title; ?></div></header>
+			<div id="<?= $collapse_id ?>" class="panel-collapse collapse<?= $this->collapsed ? '' : ' in' ?>">
+				<div class="panel-body">
+					<?= $this->lines; ?>
+				</div>
+			</div>
+		</div>
+	</section>
+</div>

--- a/fragments/mediapool_sidebar_line.php
+++ b/fragments/mediapool_sidebar_line.php
@@ -1,0 +1,13 @@
+
+<div style="display: table;">
+	<dl class="dl-horizontal text-left">
+		<?php
+		foreach ($this->exif as $key => $value) {
+			?>
+			<dt><?= $value['key'] ?></dt>
+			<dd><?= $value['value'] ?></dd>
+			<?php
+		}
+		?>
+	</dl>
+</div>

--- a/install.php
+++ b/install.php
@@ -1,0 +1,13 @@
+<?php
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+rex_sql_table::get(rex::getTable('media'))
+    ->ensurePrimaryIdColumn()
+    ->ensureColumn(new rex_sql_column('exif_json', 'longtext', true))
+    ->ensure();
+

--- a/install.php
+++ b/install.php
@@ -2,6 +2,6 @@
 
 rex_sql_table::get(rex::getTable('media'))
     ->ensurePrimaryIdColumn()
-    ->ensureColumn(new rex_sql_column('exif_json', 'longtext', true))
+    ->ensureColumn(new rex_sql_column('exif', 'longtext', true))
     ->ensure();
 

--- a/install.php
+++ b/install.php
@@ -1,11 +1,5 @@
 <?php
 
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-
 rex_sql_table::get(rex::getTable('media'))
     ->ensurePrimaryIdColumn()
     ->ensureColumn(new rex_sql_column('exif_json', 'longtext', true))

--- a/lib/rex_mediapool_exif.php
+++ b/lib/rex_mediapool_exif.php
@@ -135,7 +135,7 @@ class rex_mediapool_exif
             unset($word);
         }
 
-        $return['exif_json'] = json_encode($DATA);
+        $return['exif'] = json_encode($DATA);
         unset($DATA, $field, $lookin);
 
         if(empty($return['title']))
@@ -247,7 +247,7 @@ class rex_mediapool_exif
     {
         $subject = $ep->getSubject();
 
-        $exif = json_decode($ep->getParam('media')->getValue('exif_json'), 1);
+        $exif = json_decode($ep->getParam('media')->getValue('exif'), 1);
         if ($exif) {
             $lines = '';
             //rekursiver Aufruf einer anonymen Funktion

--- a/lib/rex_mediapool_exif.php
+++ b/lib/rex_mediapool_exif.php
@@ -60,7 +60,7 @@ class rex_mediapool_exif
 
                         if(empty($result[$key]) && !empty($value))
                         {
-                            $update[$field] = "`$key` = '$value'";
+                            $update[$field] = "`$key` = ".$sql->escape($value);
                         }
                     }
                 }
@@ -135,6 +135,7 @@ class rex_mediapool_exif
             unset($word);
         }
 
+        $return['exif_json'] = json_encode($DATA);
         unset($DATA, $field, $lookin);
 
         if(empty($return['title']))
@@ -238,6 +239,51 @@ class rex_mediapool_exif
             }
         }
         unset($path, $size, $info);
+
+        return $return;
+    }
+
+    public static function mediapoolDetailOutput (rex_extension_point $ep)/*: string*/
+    {
+        $subject = $ep->getSubject();
+
+        $exif = json_decode($ep->getParam('media')->getValue('exif_json'), 1);
+        if ($exif) {
+            $lines = '';
+            //rekursiver Aufruf einer anonymen Funktion
+            $lines .= self::mediapoolDetailOutputLine($exif);
+
+            $fragment = new \rex_fragment([
+                'collapsed' => true,
+                'title' => 'EXIF',
+                'lines' => $lines,
+            ]);
+            $subject .= $fragment->parse('fragments/mediapool_sidebar.php');
+        }
+        return $subject;
+    }
+
+    protected static function mediapoolDetailOutputLine(/*array*/ $exif)/*: string*/
+    {
+        $lines = [];
+        foreach ($exif as $key => $value) {
+            if (is_array($value)) {
+                $lines[] = [
+                    'key' => $key,
+                    'value' => self::mediapoolDetailOutputLine($value),
+                ];
+            } else {
+                $lines[] = [
+                    'key' => $key,
+                    'value' => $value,
+                ];
+            }
+        }
+
+        $fragment = new \rex_fragment([
+            'exif' => $lines,
+        ]);
+        $return = $fragment->parse('fragments/mediapool_sidebar_line.php');
 
         return $return;
     }

--- a/package.yml
+++ b/package.yml
@@ -7,3 +7,5 @@ requires:
     packages:
         mediapool: '>=2.3.0'
     redaxo: ^5.2.0
+    php:
+        extensions: [exif]


### PR DESCRIPTION
- Alle EXIF-Rohdaten in der Datenbank hinterlegen. (Dann sind sie da und können einfach verwendet/gefiltert werden)
- Beim Installieren prüfen lassen, ob die PHP-Extension "exif" installiert ist, weil sonst die Funktion exif_read_data nicht vorhanden ist ("Fatal Error")
- Ausgabe im Medienpool als aufklappbare Liste

**Warum alle Daten?**

Weil sie im Bild vorhanden sind. Was da ist, ist da und kann verwendet werden. Auch die GPS-Daten bei Handys. (Obwohl die sehr eigenwillig gespeichert sind)

**Warum als JSON?**

Dann kann man die Daten direkt bei Filterungen verwenden (zumindest in MySQL ab 5.7.8 bzw. MariaDB ab 10.2.3)

Hier im Beispiel z.B. nach Kamera (in meinem Fall kann da entweder "Apple" oder "Canon" stehen)
```sql
select exif_json,
	JSON_VALID(exif_json) valid,
	/*json_detailed(exif_json) formatted,*/ -- gibt es nicht in MySQL
	exif_json->"$.FileName" filename,
	exif_json->"$.Make" make,
	exif_json->"$.Model" model,
	exif_json->"$.Make" = 'Canon' isCanon,
	exif_json->"$.COMPUTED.ApertureFNumber" aperture,
	exif_json->"$.ExposureTime" exposure,
	exif_json->"$.ISOSpeedRatings" iso
from rex_media;
```

Äquivalent in MariaDB:
```sql
select exif_json,
	JSON_VALID(exif_json) valid,
	json_detailed(exif_json) formatted,
	json_value(exif_json,'$.FileName') filename,
	json_value(exif_json,'$.Make') make,
	json_value(exif_json,'$.Model') model,
	json_value(exif_json,'$.Make') = 'Canon' isCanon, -- z.B im where
	json_value(exif_json,'$.COMPUTED.ApertureFNumber') aperture,
	json_value(exif_json,'$.ExposureTime') exposure,
	json_value(exif_json,'$.ISOSpeedRatings') iso
from rex_media
;
```

Da die JSON-Funktionalität in MySQL und MariaDB (noch) abweicht, würde ich das eher als Beta-Feature betrachten, aber grundlegend funktioniert es erstmal.

Es ginge auch andere Daten, wie z.B. nur Hochkant ('$.Orientation' = 6) oder Quer ('$.Orientation' = 1)
Was das angeht, kann sich ja dann jeder selbst kreativ austoben…

Ach ja, um das JSON speichern zu können, musste ich im update übrigens noch ein "escape" einbauen, weil sonst die Anführungszeichen abhanden kommen und das JSON nicht mehr lesbar ist. Nebeneffekt: man kann verhindert SQL-Fehler. Ein solcher Fehler wäre z.B. denkbar, wenn ein User eine Bildbeschreibung in die Datei legt, die ein einfaches Anführungszeichen (') enthält. Es ist zwar unwahrscheinlich, kann aber passieren.

**Wie kann man auf die Daten zugreifen?**

Nur kurz als Beispiel:
```php
$media = rex_media::get($filename);
$data = json_decode($media->getValue('exif_json'), true);
var_dump($data['Make']);
var_dump($data['COMPUTED']['ApertureFNumber']);
```
Die Indexnamen kann man (sofern beim Bild vorhanden) auf der Datailseite im Medienpool nachschlagen. Das ist dann eine ausklappbare Box unterhalb des Vorschaubildes.

Ich glaube, das war erstmal alles.