### PR TITLE
Datenabfrage einbauen

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -1,8 +1,7 @@
 <?php
 
-if (class_exists(rex_fragment::class)) {
-	rex_fragment::addDirectory(realpath(__DIR__));
-}
+rex_fragment::addDirectory(realpath(__DIR__));
+
 
 rex_extension::register('MEDIA_ADDED', ['rex_mediapool_exif', 'processUploadedMedia'], rex_extension::LATE );
 rex_extension::register('MEDIA_UPDATED', ['rex_mediapool_exif', 'processUploadedMedia'], rex_extension::LATE );

--- a/install.php
+++ b/install.php
@@ -11,4 +11,4 @@ rex_metainfo_add_field('Copyright', 'med_copyright', '3', '', '1', '', '', '', '
 rex_metainfo_add_field('Autor', 'med_author', '4', '', '1', '', '', '', '');
 rex_metainfo_add_field('Ausrichtung', 'med_orientation', '5', '', '1', '', '', '', '');
 rex_metainfo_add_field('Erstellungsdatum', 'med_createdate', '6', '', '1', '', '', '', '');
-rex_metainfo_add_field('Geo-koordinaten', 'med_gps', '7', '', '1', '', '', '', '');
+rex_metainfo_add_field('Geo-Koordinaten', 'med_gps', '7', '', '1', '', '', '', '');

--- a/install.php
+++ b/install.php
@@ -11,3 +11,4 @@ rex_metainfo_add_field('Copyright', 'med_copyright', '3', '', '1', '', '', '', '
 rex_metainfo_add_field('Autor', 'med_author', '4', '', '1', '', '', '', '');
 rex_metainfo_add_field('Ausrichtung', 'med_orientation', '5', '', '1', '', '', '', '');
 rex_metainfo_add_field('Erstellungsdatum', 'med_createdate', '6', '', '1', '', '', '', '');
+rex_metainfo_add_field('Geo-koordinaten', 'med_gps', '7', '', '1', '', '', '', '');

--- a/lib/Cli/Read.php
+++ b/lib/Cli/Read.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+namespace FriendsOfRedaxo\addon\MediapoolExif\Cli;
+
+/**
+ * Datei für ...
+ *
+ * @version       1.0 / 2020-06-08
+ * @author        akrys
+ */
+use rex_console_command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Description of Renew
+ *
+ * @author akrys
+ */
+class Read
+	extends rex_console_command
+{
+
+	/**
+	 * Konsolen-Aufruf konfigurieren.
+	 */
+	protected function configure()
+	{
+		$this
+			->setName('mediapool_exif:read')
+			->setDescription('Read non-existing exif data')
+			->addOption('all', null, InputOption::VALUE_NONE, 'Renew EXIF-Data of all files.')
+			->addOption('silent', null, InputOption::VALUE_NONE, 'No confirmation (when running --all)')
+		;
+	}
+
+	/**
+	 * Dateien lesen
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output)
+	{
+		$io = $this->getStyle($input, $output);
+		$io->title('Read EXIF data');
+
+		$updateAll = $input->getOption('all');
+		$updateSilent = $input->getOption('silent');
+
+		$mode = \FriendsOfRedaxo\addon\MediapoolExif\Exif::GETMEDIA_MODE_NULL_ONLY;
+		if ($updateAll) {
+			if ($updateSilent || $io->confirm('You are going to update all files. Are you sure?', false)) {
+				$mode = \FriendsOfRedaxo\addon\MediapoolExif\Exif::GETMEDIA_MODE_ALL;
+			}
+		}
+		$files = \FriendsOfRedaxo\addon\MediapoolExif\Exif::getMediaToRead($mode);
+
+		$numEntries = count($files);
+		$io->writeln($numEntries.' entries to read');
+
+		$counter = 0;
+		foreach ($files as $file) {
+			$counter++;
+			$io->writeln('Process file '.$counter.' of '.$numEntries.': '.$file['filename']);
+
+			\rex_mediapool_exif::readExifFromFile($file['filename']);
+		}
+
+		$io->success('done');
+	}
+}

--- a/lib/Cli/Read.php
+++ b/lib/Cli/Read.php
@@ -1,18 +1,13 @@
 <?php
 
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-namespace FriendsOfRedaxo\addon\MediapoolExif\Cli;
-
 /**
  * Datei für ...
  *
  * @version       1.0 / 2020-06-08
  * @author        akrys
  */
+namespace FriendsOfRedaxo\addon\MediapoolExif\Cli;
+
 use rex_console_command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/lib/Exception/NotFoundException.php
+++ b/lib/Exception/NotFoundException.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Datei für ...
+ *
+ * @version       1.0 / 2020-06-08
+ * @author        akrys
+ */
+namespace FriendsOfRedaxo\addon\MediapoolExif\Exception;
+
+/**
+ * Description of NotFoundException
+ *
+ * @author akrys
+ */
+class NotFoundException
+	extends \Exception
+{
+	/**
+	 *
+	 * @todo activate type hint if min PHP-Version > 7.4
+	 * @var string
+	 */
+	public /* string */ $index;
+
+	/**
+	 * Konstruktor
+	 * @param string $index
+	 * @param string $message
+	 * @param int $code
+	 * @param \Throwable $previous
+	 */
+	public function __construct(string $index, string $message = "", int $code = 0, \Throwable $previous = NULL)
+	{
+		$this->index = $index;
+		parent::__construct($message, $code, $previous);
+	}
+
+	/**
+	 * Index alleine holen.
+	 * Damit kann man in einem Catch-Block eigene Infos zusammenstellen.
+	 * Was der Fehler ist, ergibt sich ja aus dem Exception-Namen.
+	 * @return string
+	 */
+	public function getIndex(): string
+	{
+		return $this->index;
+	}
+}

--- a/lib/Exif.php
+++ b/lib/Exif.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Datei für ...
+ *
+ * @version       1.0 / 2020-06-08
+ * @author        akrys
+ */
+namespace FriendsOfRedaxo\addon\MediapoolExif;
+
+use rex_media;
+
+/**
+ * Description of Exif
+ *
+ * @author akrys
+ */
+class Exif
+{
+	const MODE_THROW_EXCEPTION = 1000; //should be default
+	const MODE_RETURN_NULL = 1001;
+	const MODE_RETURN_FALSE = 1002;
+	const MODE_RETURN_ZERO = 1003;
+	const MODE_RETURN_MINUS = 1004;
+	const MODE_RETURN_EMPTY_STRING = 1005;
+	const MODE_RETURN_EMPTY_ARRAY = 1006;
+	const GETMEDIA_MODE_NULL_ONLY = 1000;
+	const GETMEDIA_MODE_ALL = 1001;
+
+	/**
+	 * Alternative Datenerhebung, analog zu rex_media::get()
+	 *
+	 * @param \FriendsOfRedaxo\addon\MediapoolExif\rex_media $media
+	 * @return ExifData
+	 */
+	public static function get(rex_media $media, $mode = self::MODE_THROW_EXCEPTION): ExifData
+	{
+		return new ExifData($media, $mode);
+	}
+
+	/**
+	 *
+	 * @param type $mode
+	 * @return array
+	 */
+	public static function getMediaToRead($mode = self::GETMEDIA_MODE_NULL_ONLY): array
+	{
+		$rexSQL = \rex_sql::factory();
+
+		switch ($mode) {
+			case self::GETMEDIA_MODE_ALL:
+				$sql = 'select filename from rex_media';
+				break;
+			case self::GETMEDIA_MODE_NULL_ONLY:
+			default:
+				$sql = 'select filename from rex_media where exif is null';
+				break;
+		}
+		return $rexSQL->getArray($sql);
+	}
+}

--- a/lib/ExifData.php
+++ b/lib/ExifData.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+namespace FriendsOfRedaxo\addon\MediapoolExif;
+
+use FriendsOfRedaxo\addon\MediapoolExif\Exception\NotFoundException;
+use rex_media;
+
+/**
+ * Datei für ...
+ *
+ * @version       1.0 / 2020-06-08
+ * @author        akrys
+ */
+
+/**
+ * Description of ExifData
+ *
+ * @author akrys
+ */
+class ExifData
+{
+	/**
+	 * Media-Objekt
+	 *
+	 * @todo activate type hint if min PHP-Version > 7.4
+	 * @var rex_media
+	 */
+	private /* rex_media */ $media;
+
+	/**
+	 * Modus
+	 * @var int
+	 */
+	private /* int */ $mode;
+
+	/**
+	 * Konstruktor
+	 *
+	 * Modus für die Fehlerbehandlung
+	 * Standard: MODE_THROW_EXCEPTION
+	 *
+	 * Wer keine try/catch-Blocke mag, kann sich in dem Fall dann andere false-Werte liefern lassen.
+	 *
+	 * Die Gefahr, dass Code-Technisch nicht mehr erkannt werden kann, ob es ein Fehler gab oder ob der Wert
+	 * tatsächlich 0 oder false oder was auch immer ist, liegt dann natürlich beim jeweiligen Entwickler.
+	 * Garantierte Eindeutigkeit gibt es nur im Modus MODE_THROW_EXCEPTION. (Darum auch der Standard)
+	 *
+	 * <ul>
+	 * <li>false (MODE_RETURN_FALSE)</li>
+	 * <li>null (MODE_RETURN_NULL)</li>
+	 * <li>0 (MODE_RETURN_ZERO)</li>
+	 * <li>-1 (MODE_RETURN_MINUS)</li>
+	 * <li>'' (MODE_RETURN_EMPTY_STRING)</li>
+	 * <li>[] (MODE_RETURN_EMPTY_ARRAY)</li>
+	 * </ol>
+	 *
+	 * @param \FriendsOfRedaxo\addon\MediapoolExif\rex_media $media
+	 * @param int $mode
+	 */
+	public function __construct(rex_media $media, int $mode = null)
+	{
+		$this->media = $media;
+
+		if ($mode === null) {
+			$mode = Exif::MODE_THROW_EXCEPTION;
+		}
+		$this->mode = $mode;
+	}
+
+	/**
+	 * Daten holen
+	 *
+	 * Ist der Index nicht gesetzt, kommt alles in Form eines Arrays zurück.
+	 *
+	 * @param string $index
+	 * @return mixed
+	 * @throws NotFoundException
+	 */
+	public function get(string $index = null)
+	{
+		$data = json_decode($this->media->getValue('exif'), true);
+
+		if ($index !== null) {
+			if (!array_key_exists($index, $data)) {
+				return $this->handleNotFound($index);
+			}
+			return $data[$index];
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Fehler-Behandlung
+	 *
+	 * Welche Rückgabe hätten's gern?
+	 *
+	 * @param string $index
+	 * @return mixed
+	 * @throws NotFoundException
+	 */
+	private function handleNotFound(string $index)
+	{
+		$return = '';
+
+		switch ($this->mode) {
+			case Exif::MODE_RETURN_NULL:
+				$return = null;
+				break;
+			case Exif::MODE_RETURN_FALSE:
+				$return = false;
+				break;
+			case Exif::MODE_RETURN_ZERO:
+				$return = 0;
+				break;
+			case Exif::MODE_RETURN_MINUS:
+				$return = -1;
+				break;
+			case Exif::MODE_RETURN_EMPTY_STRING:
+				$return = '';
+				break;
+			case Exif::MODE_RETURN_EMPTY_ARRAY:
+				$return = [];
+				break;
+			case Exif::MODE_THROW_EXCEPTION:
+			default:
+				throw new NotFoundException($index, 'Index not found: '.$index);
+		}
+		return $return;
+	}
+}

--- a/lib/rex_mediapool_exif.php
+++ b/lib/rex_mediapool_exif.php
@@ -10,7 +10,7 @@ class rex_mediapool_exif
         'keywords' => 'Keywords',
         'title' => ['DocumentTitle', 'Headline'],
         'description' => 'Caption',
-        'categories' => 'Subcategories',		
+        'categories' => 'Subcategories',
 		'gps'         => 'GPSCoordinates',
     ];
 
@@ -185,7 +185,7 @@ class rex_mediapool_exif
 				if($exif['GPSLatitude'] && $exif['GPSLatitudeRef'] && $exif['GPSLongitude'] && $exif['GPSLongitudeRef']) {
 					$exif['GPSCoordinates'] = static::convertGPSCoordinates($exif['GPSLatitude'], $exif['GPSLatitudeRef'], $exif['GPSLongitude'], $exif['GPSLongitudeRef']);
 				}
-				
+
                 return $exif;
             }
         }
@@ -248,7 +248,7 @@ class rex_mediapool_exif
         return $return;
     }
 
-    public static function mediapoolDetailOutput (rex_extension_point $ep)/*: string*/
+    public static function mediapoolDetailOutput (rex_extension_point $ep): string
     {
         $subject = $ep->getSubject();
 
@@ -258,7 +258,7 @@ class rex_mediapool_exif
             //rekursiver Aufruf einer anonymen Funktion
             $lines .= self::mediapoolDetailOutputLine($exif);
 
-            $fragment = new \rex_fragment([
+            $fragment = new rex_fragment([
                 'collapsed' => true,
                 'title' => 'EXIF',
                 'lines' => $lines,
@@ -268,7 +268,7 @@ class rex_mediapool_exif
         return $subject;
     }
 
-    protected static function mediapoolDetailOutputLine(/*array*/ $exif)/*: string*/
+    protected static function mediapoolDetailOutputLine(array $exif): string
     {
         $lines = [];
         foreach ($exif as $key => $value) {
@@ -285,7 +285,7 @@ class rex_mediapool_exif
             }
         }
 
-        $fragment = new \rex_fragment([
+        $fragment = new rex_fragment([
             'exif' => $lines,
         ]);
         $return = $fragment->parse('fragments/mediapool_sidebar_line.php');
@@ -294,23 +294,23 @@ class rex_mediapool_exif
     }
 
 	protected static function convertGPSCoordinates($GPSLatitude, $GPSLatitude_Ref, $GPSLongitude, $GPSLongitude_Ref)
-	{		
+	{
 		$GPSLatfaktor  = 1;
 		$GPSLongfaktor = 1;
-		
+
 		if($GPSLatitude_Ref == 'S') $GPSLatfaktor = -1;
 		if($GPSLongitude_Ref == 'W') $GPSLongfaktor = -1;
-		
+
 		$GPSLatitude_h = explode("/", $GPSLatitude[0]);
 		$GPSLatitude_m = explode("/", $GPSLatitude[1]);
 		$GPSLatitude_s = explode("/", $GPSLatitude[2]);
-		
+
 		$GPSLat_h = $GPSLatitude_h[0] / $GPSLatitude_h[1];
 		$GPSLat_m = $GPSLatitude_m[0] / $GPSLatitude_m[1];
 		$GPSLat_s = $GPSLatitude_s[0] / $GPSLatitude_s[1];
-		
+
 		$GPSLatGrad = $GPSLatfaktor * ($GPSLat_h + ($GPSLat_m + ($GPSLat_s / 60)) / 60);
-		
+
 		$GPSLongitude_h = explode("/", $GPSLongitude[0]);
 		$GPSLongitude_m = explode("/", $GPSLongitude[1]);
 		$GPSLongitude_s = explode("/", $GPSLongitude[2]);
@@ -318,7 +318,17 @@ class rex_mediapool_exif
 		$GPSLong_m      = $GPSLongitude_m[0] / $GPSLongitude_m[1];
 		$GPSLong_s      = $GPSLongitude_s[0] / $GPSLongitude_s[1];
 		$GPSLongGrad    = $GPSLongfaktor * ($GPSLong_h + ($GPSLong_m + ($GPSLong_s / 60)) / 60);
-		
+
 		return number_format($GPSLatGrad, 6,'.','') . ',' . number_format($GPSLongGrad, 6,'.','');
 	}
+
+    public function readExifFromFile($filename): void
+    {
+        $subject = null;
+        $params = [
+            'filename' =>$filename,
+        ];
+        $ep = new rex_extension_point('dummy', $subject, $params, false);
+        rex_mediapool_exif::processUploadedMedia($ep);
+    }
 }

--- a/lib/rex_mediapool_exif.php
+++ b/lib/rex_mediapool_exif.php
@@ -182,7 +182,7 @@ class rex_mediapool_exif
             $path = rex_path::media($media->getFileName());
             if($exif = exif_read_data($path, 'ANY_TAG'))
             {
-				if($exif['GPSLatitude'] && $exif['GPSLatitudeRef'] && $exif['GPSLongitude'] && $exif['GPSLongitudeRef']) {
+				if(isset($exif['GPSLatitude']) && isset($exif['GPSLatitudeRef']) && isset($exif['GPSLongitude']) && isset($exif['GPSLongitudeRef'])) {
 					$exif['GPSCoordinates'] = static::convertGPSCoordinates($exif['GPSLatitude'], $exif['GPSLatitudeRef'], $exif['GPSLongitude'], $exif['GPSLongitudeRef']);
 				}
 

--- a/package.yml
+++ b/package.yml
@@ -3,9 +3,14 @@ version: '1.0.0'
 author: 'FriendsOfREDAXO'
 supportpage: https://github.com/FriendsOfREDAXO/mediapool_exif
 
+console_commands:
+    mediapool_exif:read: '\FriendsOfRedaxo\addon\MediapoolExif\Cli\Read'
+
+
 requires:
     packages:
         mediapool: '>=2.3.0'
     redaxo: ^5.2.0
     php:
+        version: '>=7.1'
         extensions: [exif]


### PR DESCRIPTION
Bug-Fixes:
- Existenz von rex_fragment braucht nicht geprüft werden
- Bugs aus Merge PR1:
  - Geo-Koordinatenfeld aus PR1 wurde nicht angelegt.
  - PHP-Notice "undefined index", wenn keine Koordinaten im Bild vorhanden sind

neue Features:
- Besserer Zugriff s.u.
- Konsolen-Kommando "EXIF-Daten neu einlesen" (`redaxo/bin/console mediapool_exif:read`)
  - Auch: alle Daten neu schreiben (`redaxo/bin/console mediapool_exif:read --all`)
  - Und dabei ohne Nachfrage, ob man denn sicher sei (`redaxo/bin/console mediapool_exif:read --all --silent`)
- minimale PHP-Version nun 7.1
  - wie bei Redaxo Core
  - Auskommentierte Parameter- und Returntypes können scharf gestellt werden.

Datenzugriff:
Hinweis: Da die EXIF-Daten in der `rex_media`-Tabelle liegen, kann man auch ganz traditionell drauf zugreifen, dann muss man sich um das JSON-Handling allerdings selbst kümmern.
```php
$media = rex_media::get($value['filename']);
var_dump(json_decode($media->getValue('exif'), true));
```

Einfacher ist es sich das über die EXIF-Klasse zu holen. (Wenn man den Parameter $exif->get() weglässt, bekommt man auch das ganze Array.)
Beispiel:
```php
try {
    $media = rex_media::get($value['filename']);
    $exif = \FriendsOfRedaxo\addon\MediapoolExif\Exif::get($media);
    //Parameter bei $exif->get() ist optional. Wenn nicht angegeben kommt das komplette Array
    var_dump($exif->get('Make'));
} catch (FriendsOfRedaxo\addon\MediapoolExif\Exception\NotFoundException $e) {
    echo $e->getIndex().' nicht da :-(';
}
```
  - Im PHP-Umfeld soll es noch Leute geben, die nicht so gerne mit Exceptions arbeiten. Wer im Fehlerfall lieber ein `false` oder `null` zurück bekommt, kann auch das auch machen. Das ist aber nicht das Standard-Vorgehen.
```php
$media = rex_media::get($value['filename']);
$exif = \FriendsOfRedaxo\addon\MediapoolExif\Exif::get($media, \FriendsOfRedaxo\addon\MediapoolExif\Exif::MODE_RETURN_FALSE);
$index = 'Make';
//Parameter bei $exif->get() ist optional. Wenn nicht angegeben kommt das komplette Array
$vendor = $exif->get($index);
if(!$vendor) {
    echo $index.' nicht da :-(';
} else {
    var_dump($vendor);
}
```