### PR TITLE
fixes #21

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -10,6 +10,7 @@ console_commands:
 requires:
     packages:
         mediapool: '>=2.3.0'
+        metainfo: '>=2.7.1'
     redaxo: ^5.2.0
     php:
         version: '>=7.1'


### PR DESCRIPTION
Die Zusatzfelder im media-objekt werden über die Metainfo-Funktionen realisiert.
Daher wird das Addon benötigt und mit diesem Fix auch auch eingefordert.