### PR TITLE
v3.0 Umstellung auf PHP 8.1

### DIFF
--- a/lib/Cli/Read.php
+++ b/lib/Cli/Read.php
@@ -21,14 +21,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author akrys
  */
-class Read
-	extends rex_console_command
+class Read extends rex_console_command
 {
 
 	/**
 	 * Konsolen-Aufruf konfigurieren.
 	 */
-	protected function configure()
+	protected function configure(): void
 	{
 		$this
 			->setName('mediapool_exif:read')
@@ -43,7 +42,7 @@ class Read
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output)
+	protected function execute(InputInterface $input, OutputInterface $output): void
 	{
 		$io = $this->getStyle($input, $output);
 		$io->title('Read EXIF data');

--- a/lib/Enum/Format.php
+++ b/lib/Enum/Format.php
@@ -18,8 +18,8 @@ namespace FriendsOfRedaxo\addon\MediapoolExif\Enum;
  *
  * @author akrys
  */
-class /* enum */ Format /* :string */
+enum Format :string
 {
-	const /*case*/ RAW = 'numeric';
-	const /*case*/ READABLE = 'readable';
+	case RAW = 'numeric';
+	case READABLE = 'readable';
 }

--- a/lib/Enum/IptcDefinitions.php
+++ b/lib/Enum/IptcDefinitions.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Scripting/PHPEnum.php to edit this template
+ */
+namespace FriendsOfRedaxo\addon\MediapoolExif\Enum;
+
+/**
+ *
+ * @author akrys
+ */
+enum IptcDefinitions
+{
+	case DOCUMENT_TITLE; //2#005'  | DocumentTitle
+	case URGENCY; //2#010'  | Urgency
+	case CATEGORY; //2#015'  | Category
+	case SUBCATEGORIES; //2#020'  | Subcategories
+	case KEYWORDS; //2#025'  | Keywords
+	case SPECIAL_INSTRUCTIONS; //2#040'  | SpecialInstructions
+	case CREATION_DATE; //2#055'  | CreationDate
+	case AUTHOR_BY_LINE; //2#080'  | AuthorByline
+	case AUTHOR_TITLE; //2#085'  | AuthorTitle
+	case CITY; //2#090'  | City
+	case STATE; //2#095'  | State
+	case COUNTRY; //2#101'  | Country
+	case OTR; //2#103'  | OTR
+	case HEADLINE; //2#105'  | Headline
+	case SOURCE; //2#110'  | Source
+	case PHOTO_SOURCE; //2#115'  | PhotoSource
+	case COPYRIGHT; //2#116'  | Copyright
+	case CAPTION; //2#120'  | Caption
+	case CAPTION_WRITER; //2#122'  | CaptionWriter
+
+	public function getCode(): string
+	{
+		return match ($this) {
+			self::DOCUMENT_TITLE => '2#005',
+			self::URGENCY => '2#010',
+			self::CATEGORY => '2#015',
+			self::SUBCATEGORIES => '2#020',
+			self::KEYWORDS => '2#025',
+			self::SPECIAL_INSTRUCTIONS => '2#040',
+			self::CREATION_DATE => '2#055',
+			self::AUTHOR_BY_LINE => '2#080',
+			self::AUTHOR_TITLE => '2#085',
+			self::CITY => '2#090',
+			self::STATE => '2#095',
+			self::COUNTRY => '2#101',
+			self::OTR => '2#103',
+			self::HEADLINE => '2#105',
+			self::SOURCE => '2#110',
+			self::PHOTO_SOURCE => '2#115',
+			self::COPYRIGHT => '2#116',
+			self::CAPTION => '2#120',
+			self::CAPTION_WRITER => '2#122',
+		};
+	}
+
+	public function getLabel(): string
+	{
+		return match ($this) {
+			self::DOCUMENT_TITLE => 'DocumentTitle',
+			self::URGENCY => 'Urgency',
+			self::CATEGORY => 'Category',
+			self::SUBCATEGORIES => 'Subcategories',
+			self::KEYWORDS => 'Keywords',
+			self::SPECIAL_INSTRUCTIONS => 'SpecialInstructions',
+			self::CREATION_DATE => 'CreationDate',
+			self::AUTHOR_BY_LINE => 'AuthorByline',
+			self::AUTHOR_TITLE => 'AuthorTitle',
+			self::CITY => 'City',
+			self::STATE => 'State',
+			self::COUNTRY => 'Country',
+			self::OTR => 'OTR',
+			self::HEADLINE => 'Headline',
+			self::SOURCE => 'Source',
+			self::PHOTO_SOURCE => 'PhotoSource',
+			self::COPYRIGHT => 'Copyright',
+			self::CAPTION => 'Caption',
+			self::CAPTION_WRITER => 'CaptionWriter',
+		};
+	}
+}

--- a/lib/Enum/MediaFetchMode.php
+++ b/lib/Enum/MediaFetchMode.php
@@ -19,8 +19,8 @@ namespace FriendsOfRedaxo\addon\MediapoolExif\Enum;
  *
  * @author akrys
  */
-class /*enum*/ MediaFetchMode /*:int*/
+enum MediaFetchMode :int
 {
-	const /*case*/ NULL_ONLY = 1000;
-	const /*case*/ ALL = 1001;
+	case NULL_ONLY = 1000;
+	case ALL = 1001;
 }

--- a/lib/Enum/ReturnMode.php
+++ b/lib/Enum/ReturnMode.php
@@ -4,7 +4,6 @@
  * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
  * Click nbfs://nbhost/SystemFileSystem/Templates/Scripting/PHPClass.php to edit this template
  */
-
 namespace FriendsOfRedaxo\addon\MediapoolExif\Enum;
 
 /**
@@ -19,13 +18,13 @@ namespace FriendsOfRedaxo\addon\MediapoolExif\Enum;
  *
  * @author akrys
  */
-class /*enum*/ ReturnMode /*:int*/
+enum ReturnMode: int
 {
-	const /*case*/ THROW_EXCEPTION = 1000; //should be default
-	const /*case*/ RETURN_NULL = 1001;
-	const /*case*/ RETURN_FALSE = 1002;
-	const /*case*/ RETURN_ZERO = 1003;
-	const /*case*/ RETURN_MINUS = 1004;
-	const /*case*/ RETURN_EMPTY_STRING = 1005;
-	const /*case*/ RETURN_EMPTY_ARRAY = 1006;
+	case THROW_EXCEPTION = 1000; //should be default
+	case RETURN_NULL = 1001;
+	case RETURN_FALSE = 1002;
+	case RETURN_ZERO = 1003;
+	case RETURN_MINUS = 1004;
+	case RETURN_EMPTY_STRING = 1005;
+	case RETURN_EMPTY_ARRAY = 1006;
 }

--- a/lib/Exception/InvalidFormatExcption.php
+++ b/lib/Exception/InvalidFormatExcption.php
@@ -9,6 +9,7 @@
 namespace FriendsOfRedaxo\addon\MediapoolExif\Exception;
 
 use Exception;
+use FriendsOfRedaxo\addon\MediapoolExif\Enum\Format;
 use Throwable;
 
 /**
@@ -16,15 +17,14 @@ use Throwable;
  *
  * @author akrys
  */
-class InvalidFormatExcption
-	extends Exception
+class InvalidFormatExcption extends Exception
 {
 	/**
 	 *
 	 * @todo activate type hint if min PHP-Version > 7.4
-	 * @var string
+	 * @var Format
 	 */
-	public /* string */ $format;
+	public Format $format;
 
 	/**
 	 * Konstruktor
@@ -33,20 +33,20 @@ class InvalidFormatExcption
 	 * @param int $code
 	 * @param Throwable $previous
 	 */
-	public function __construct(string $format, string $message = "", int $code = 0, Throwable $previous = NULL)
+	public function __construct(Format $format, string $message = "", int $code = 0, Throwable $previous = NULL)
 	{
 		$this->format = $format;
 		if ($message === '') {
-			$message = 'Invalid Format: '.$format;
+			$message = 'Invalid Format: '.$format->value;
 		}
 		parent::__construct($message, $code, $previous);
 	}
 
 	/**
 	 * Formatname
-	 * @return string
+	 * @return Format
 	 */
-	public function getFormat(): string
+	public function getFormat(): Format
 	{
 		return $this->format;
 	}

--- a/lib/Exception/InvalidFormatExcption.php
+++ b/lib/Exception/InvalidFormatExcption.php
@@ -20,8 +20,6 @@ use Throwable;
 class InvalidFormatExcption extends Exception
 {
 	/**
-	 *
-	 * @todo activate type hint if min PHP-Version > 7.4
 	 * @var Format
 	 */
 	public Format $format;

--- a/lib/Exception/IptcException.php
+++ b/lib/Exception/IptcException.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
+ * Click nbfs://nbhost/SystemFileSystem/Templates/Scripting/PHPClass.php to edit this template
+ */
+namespace FriendsOfRedaxo\addon\MediapoolExif\Exception;
+
+use Exception;
+
+/**
+ * Datei für ...
+ *
+ * @version       1.0 / 2023-12-09
+ * @author        akrys
+ */
+
+/**
+ * Description of IptcException
+ *
+ * @author akrys
+ */
+class IptcException extends Exception
+{
+
+}

--- a/lib/Exception/NotFoundException.php
+++ b/lib/Exception/NotFoundException.php
@@ -19,8 +19,6 @@ use Throwable;
 class NotFoundException extends Exception
 {
 	/**
-	 *
-	 * @todo activate type hint if min PHP-Version > 7.4
 	 * @var string
 	 */
 	public string $index;

--- a/lib/Exception/NotFoundException.php
+++ b/lib/Exception/NotFoundException.php
@@ -16,15 +16,14 @@ use Throwable;
  *
  * @author akrys
  */
-class NotFoundException
-	extends Exception
+class NotFoundException extends Exception
 {
 	/**
 	 *
 	 * @todo activate type hint if min PHP-Version > 7.4
 	 * @var string
 	 */
-	public /* string */ $index;
+	public string $index;
 
 	/**
 	 * Konstruktor

--- a/lib/Exif.php
+++ b/lib/Exif.php
@@ -8,6 +8,8 @@
  */
 namespace FriendsOfRedaxo\addon\MediapoolExif;
 
+use FriendsOfRedaxo\addon\MediapoolExif\Enum\MediaFetchMode;
+use FriendsOfRedaxo\addon\MediapoolExif\Enum\ReturnMode;
 use FriendsOfRedaxo\addon\MediapoolExif\ExifData;
 use rex_media;
 use rex_sql;
@@ -19,32 +21,13 @@ use rex_sql;
  */
 class Exif
 {
-	/** @deprecated use FriendsOfRedaxo\addon\MediapoolExi\Enum\Mode::THROW_EXCEPTION */
-	const MODE_THROW_EXCEPTION = 1000; //should be default
-	/** @deprecated use FriendsOfRedaxo\addon\MediapoolExi\Enum\Mode::RETURN_NULL */
-	const MODE_RETURN_NULL = 1001;
-	/** @deprecated use FriendsOfRedaxo\addon\MediapoolExi\Enum\Mode::RETURN_FALSE */
-	const MODE_RETURN_FALSE = 1002;
-	/** @deprecated use FriendsOfRedaxo\addon\MediapoolExi\Enum\Mode::RETURN_ZERO */
-	const MODE_RETURN_ZERO = 1003;
-	/** @deprecated use FriendsOfRedaxo\addon\MediapoolExi\Enum\Mode::RETURN_MINUS */
-	const MODE_RETURN_MINUS = 1004;
-	/** @deprecated use FriendsOfRedaxo\addon\MediapoolExi\Enum\Mode::RETURN_EMPTY_STRING */
-	const MODE_RETURN_EMPTY_STRING = 1005;
-	/** @deprecated use FriendsOfRedaxo\addon\MediapoolExi\Enum\Mode::RETURN_EMPTY_ARRAY */
-	const MODE_RETURN_EMPTY_ARRAY = 1006;
-	/** @deprecated use FriendsOfRedaxo\addon\MediapoolExi\Enum\MediaFetchMode::NULL_ONLY */
-	const GETMEDIA_MODE_NULL_ONLY = 1000;
-	/** @deprecated use FriendsOfRedaxo\addon\MediapoolExi\Enum\MediaFetchMode::All */
-	const GETMEDIA_MODE_ALL = 1001;
-
 	/**
 	 * Alternative Datenerhebung, analog zu rex_media::get()
 	 *
 	 * @param \FriendsOfRedaxo\addon\MediapoolExif\rex_media $media
 	 * @return ExifData
 	 */
-	public static function get(rex_media $media, /*Enum\Mode*/ $mode = Enum\ReturnMode::THROW_EXCEPTION): ExifData
+	public static function get(rex_media $media, ReturnMode $mode = ReturnMode::THROW_EXCEPTION): ExifData
 	{
 		return new ExifData($media, $mode);
 	}
@@ -54,15 +37,15 @@ class Exif
 	 * @param type $mode
 	 * @return array
 	 */
-	public static function getMediaToRead(/*Enum\MediaFetchMode*/ $mode = Enum\MediaFetchMode::NULL_ONLY): array
+	public static function getMediaToRead(MediaFetchMode $mode = MediaFetchMode::NULL_ONLY): array
 	{
 		$rexSQL = rex_sql::factory();
 
 		switch ($mode) {
-			case Enum\MediaFetchMode::ALL:
+			case MediaFetchMode::ALL:
 				$sql = 'select filename from rex_media';
 				break;
-			case Enum\MediaFetchMode::NULL_ONLY:
+			case MediaFetchMode::NULL_ONLY:
 			default:
 				$sql = 'select filename from rex_media where exif is null';
 				break;

--- a/lib/ExifData.php
+++ b/lib/ExifData.php
@@ -25,7 +25,6 @@ class ExifData
 	/**
 	 * Media-Objekt
 	 *
-	 * @todo activate type hint if min PHP-Version > 7.4
 	 * @var rex_media
 	 */
 	private rex_media $media;
@@ -33,8 +32,7 @@ class ExifData
 	/**
 	 * Exif-Daten-Array
 	 *
-	 * @todo activate type hint if min PHP-Version > 7.4
-	 * @var rex_media
+	 * @var array
 	 */
 	private array $exif;
 

--- a/lib/ExifData.php
+++ b/lib/ExifData.php
@@ -112,16 +112,18 @@ class ExifData
 	 * Formatierungsalgorithmus anstoßen
 	 * @param string $type
 	 * @param Format $format
+	 * @param string $className
 	 * @return mixed
 	 */
-	public function format(string $type, Format $format = null, ?string $className=null): mixed
+	public function format(string $className, Format $format = null): mixed
 	{
 		try {
-			if(!$className) {
-				$className = '\\FriendsOfRedaxo\\addon\\MediapoolExif\\Format\\'.ucfirst($type);
+			if (!class_exists($className)) {
+				//fallback, old call
+				$className = '\\FriendsOfRedaxo\\addon\\MediapoolExif\\Format\\'.ucfirst($className);
 			}
 
-			return FormatInterface::get($this->exif, $format, $className)->format();
+			return FormatInterface::get($this->exif, $className, $format)->format();
 		} catch (Exception $e) {
 			return $this->handleExcption($e);
 		}

--- a/lib/ExifData.php
+++ b/lib/ExifData.php
@@ -114,10 +114,14 @@ class ExifData
 	 * @param Format $format
 	 * @return mixed
 	 */
-	public function format(string $type, Format $format = null): mixed
+	public function format(string $type, Format $format = null, ?string $className=null): mixed
 	{
 		try {
-			return FormatInterface::get($this->exif, $type, $format)->format();
+			if(!$className) {
+				$className = '\\FriendsOfRedaxo\\addon\\MediapoolExif\\Format\\'.ucfirst($type);
+			}
+
+			return FormatInterface::get($this->exif, $format, $className)->format();
 		} catch (Exception $e) {
 			return $this->handleExcption($e);
 		}

--- a/lib/ExifData.php
+++ b/lib/ExifData.php
@@ -9,6 +9,7 @@
 namespace FriendsOfRedaxo\addon\MediapoolExif;
 
 use Exception;
+use FriendsOfRedaxo\addon\MediapoolExif\Enum\Format;
 use FriendsOfRedaxo\addon\MediapoolExif\Enum\ReturnMode;
 use FriendsOfRedaxo\addon\MediapoolExif\Exception\NotFoundException;
 use FriendsOfRedaxo\addon\MediapoolExif\Format\FormatInterface;
@@ -27,7 +28,7 @@ class ExifData
 	 * @todo activate type hint if min PHP-Version > 7.4
 	 * @var rex_media
 	 */
-	private /* rex_media */ $media;
+	private rex_media $media;
 
 	/**
 	 * Exif-Daten-Array
@@ -35,13 +36,13 @@ class ExifData
 	 * @todo activate type hint if min PHP-Version > 7.4
 	 * @var rex_media
 	 */
-	private /* array */ $exif;
+	private array $exif;
 
 	/**
 	 * Modus
-	 * @var int
+	 * @var ReturnMode
 	 */
-	private /* int */ $mode;
+	private ReturnMode $mode;
 
 	/**
 	 * Konstruktor
@@ -67,13 +68,13 @@ class ExifData
 	 * @param \FriendsOfRedaxo\addon\MediapoolExif\rex_media $media
 	 * @param int $mode
 	 */
-	public function __construct(rex_media $media, int $mode = null)
+	public function __construct(rex_media $media, ReturnMode $mode = null)
 	{
 		$this->media = $media;
 		$this->exif = [];
 
 		$exifRaw = $this->media->getValue('exif');
-		if($exifRaw !== null){
+		if ($exifRaw !== null) {
 			$this->exif = json_decode($exifRaw, true);
 			if (!$this->exif) {
 				$this->exif = [];
@@ -95,7 +96,7 @@ class ExifData
 	 * @return mixed
 	 * @throws NotFoundException
 	 */
-	public function get(string $index = null)
+	public function get(string $index = null): mixed
 	{
 		if ($index !== null) {
 			if (!array_key_exists($index, $this->exif)) {
@@ -104,16 +105,17 @@ class ExifData
 			return $this->exif[$index];
 		}
 
-		return $data;
+		var_dump($this->exif);
+		return $this->exif;
 	}
 
 	/**
 	 * Formatierungsalgorithmus anstoßen
 	 * @param string $type
-	 * @param string $format
+	 * @param Format $format
 	 * @return mixed
 	 */
-	public function format(string $type, string $format = null)
+	public function format(string $type, Format $format = null): mixed
 	{
 		try {
 			return FormatInterface::get($this->exif, $type, $format)->format();
@@ -131,7 +133,7 @@ class ExifData
 	 * @return mixed
 	 * @throws NotFoundException
 	 */
-	private function handleExcption(Exception $exception)
+	private function handleExcption(Exception $exception): mixed
 	{
 		$return = '';
 

--- a/lib/Format/Camera.php
+++ b/lib/Format/Camera.php
@@ -24,11 +24,6 @@ use FriendsOfRedaxo\addon\MediapoolExif\Format\FormatInterface;
  */
 class Camera extends FormatInterface
 {
-	/** @deprecated use \FriendsOfRedaxo\addon\MediapoolExif\Enum\Format::RAW */
-	const TYPE_NUMERIC = 'numeric';
-
-	/** @deprecated use \FriendsOfRedaxo\addon\MediapoolExif\Enum\Format::READABLE */
-	const TYPE_READABLE = 'readable';
 
 	/**
 	 * Daten formatieren
@@ -36,7 +31,7 @@ class Camera extends FormatInterface
 	 * @throws Exception
 	 * @throws InvalidFormatExcption
 	 */
-	public function format()
+	public function format(): array
 	{
 		if (!isset($this->data['Make']) && !isset($this->data['Model'])) {
 			throw new Exception('No camera data found');
@@ -47,8 +42,10 @@ class Camera extends FormatInterface
 			$format = Format::READABLE;
 		}
 
-		if (is_callable([$this, $format])) {
-			return $this->$format();
+		$formatValue = $format->value;
+
+		if (is_callable([$this, $formatValue])) {
+			return $this->$formatValue();
 		}
 		throw new InvalidFormatExcption($format);
 	}
@@ -57,7 +54,7 @@ class Camera extends FormatInterface
 	 * Daten lesbar anzeigen
 	 * @return array
 	 */
-	private function readable()
+	private function readable(): array
 	{
 		return [
 			'make' => $this->data['Make'],
@@ -73,7 +70,7 @@ class Camera extends FormatInterface
 	 * Daten nummerisch anzeigen
 	 * @return array
 	 */
-	private function numeric()
+	private function numeric(): array
 	{
 		return [
 			'make' => $this->data['Make'],

--- a/lib/Format/Camera/Aperture.php
+++ b/lib/Format/Camera/Aperture.php
@@ -17,8 +17,7 @@ use FriendsOfRedaxo\addon\MediapoolExif\Format\FormatInterface;
  *
  * @author akrys
  */
-class Aperture
-	extends FormatInterface
+class Aperture extends FormatInterface
 {
 
 	/**
@@ -26,7 +25,7 @@ class Aperture
 	 * @return string
 	 * @throws Exception
 	 */
-	public function format()
+	public function format(): string
 	{
 		if (!isset($this->data['FNumber'])) {
 			throw new Exception('No aperture found');

--- a/lib/Format/Camera/Exposure.php
+++ b/lib/Format/Camera/Exposure.php
@@ -24,22 +24,25 @@ class Exposure extends FormatInterface
 	 * Daten formatieren
 	 * @return string
 	 * @throws Exception
-	 */ public function format(): string
+	 */
+	public function format(): string
 	{
 		if (!isset($this->data['ExposureTime'])) {
 			throw new Exception('No aperture found');
 		}
 
+		$return = '';
 		$data = explode('/', $this->data['ExposureTime']);
 		switch ($this->format) {
 			case Format::READABLE:
-				return $data[0].'/'.$data[1].' s';
+				$return= $data[0].'/'.$data[1].' s';
 				break;
 			case Format::RAW:
 			default:
-				$reutrn = (float) $data[0] / (float) $data[1];
-				return (string) $return;
+				$tmp = (float) $data[0] / (float) $data[1];
+				$return = (string) $tmp;
 				break;
 		}
+		return $return;
 	}
 }

--- a/lib/Format/Camera/Exposure.php
+++ b/lib/Format/Camera/Exposure.php
@@ -17,15 +17,14 @@ use FriendsOfRedaxo\addon\MediapoolExif\Format\FormatInterface;
  *
  * @author akrys
  */
-class Exposure
-	extends FormatInterface
+class Exposure extends FormatInterface
 {
 
 	/**
 	 * Daten formatieren
 	 * @return string
 	 * @throws Exception
-	 */	public function format()
+	 */ public function format(): string
 	{
 		if (!isset($this->data['ExposureTime'])) {
 			throw new Exception('No aperture found');
@@ -37,7 +36,9 @@ class Exposure
 				return $data[0].'/'.$data[1].' s';
 				break;
 			case Format::RAW:
-				return (float) $data[0] / (float) $data[1];
+			default:
+				$reutrn = (float) $data[0] / (float) $data[1];
+				return (string) $return;
 				break;
 		}
 	}

--- a/lib/Format/Camera/Iso.php
+++ b/lib/Format/Camera/Iso.php
@@ -16,8 +16,7 @@ use FriendsOfRedaxo\addon\MediapoolExif\Format\FormatInterface;
  *
  * @author akrys
  */
-class Iso
-	extends FormatInterface
+class Iso extends FormatInterface
 {
 
 	/**
@@ -25,7 +24,7 @@ class Iso
 	 * @return string
 	 * @throws Exception
 	 */
-	public function format()
+	public function format(): string
 	{
 		if (!isset($this->data['ISOSpeedRatings'])) {
 			throw new Exception('No aperture found');

--- a/lib/Format/Camera/Length.php
+++ b/lib/Format/Camera/Length.php
@@ -31,7 +31,7 @@ class Length extends FormatInterface
 	 * @return string
 	 * @throws Exception
 	 */
-	public function format()
+	public function format(): string
 	{
 		if (!isset($this->data['FocalLength'])) {
 			throw new Exception('No aperture found');
@@ -44,6 +44,7 @@ class Length extends FormatInterface
 				return $value.' mm';
 				break;
 			case Format::RAW:
+			default:
 				return $value;
 				break;
 		}

--- a/lib/Format/FormatInterface.php
+++ b/lib/Format/FormatInterface.php
@@ -67,8 +67,8 @@ abstract class FormatInterface
 	 * <ul>
 	 *
 	 * @param string $data exif-Daten-Array
-	 * @param Format|null $format Format-Parameter
 	 * @param string $className Formatter Namespace
+	 * @param Format|null $format Format-Parameter
 	 * @return \FriendsOfRedaxo\addon\MediapoolExif\Format\className
 	 * @throws InvalidFormatExcption
 	 */

--- a/lib/Format/FormatInterface.php
+++ b/lib/Format/FormatInterface.php
@@ -69,12 +69,12 @@ abstract class FormatInterface
 	 * @param string $data exif-Daten-Array
 	 * @param string $type KlasseName des Formatters
 	 * @param Format|null $format Format-Parameter
+	 * @param string $className Formatter Namespace
 	 * @return \FriendsOfRedaxo\addon\MediapoolExif\Format\className
 	 * @throws InvalidFormatExcption
 	 */
-	public static function get($data, $type, ?Format $format = null): FormatInterface
+	public static function get($data, ?Format $format = null, ?string $className = null): FormatInterface
 	{
-		$className = __NAMESPACE__.'\\'.ucfirst($type);
 		if (class_exists($className)) {
 			$object = new $className($data, $format);
 			if (is_a($object, FormatInterface::class)) {

--- a/lib/Format/FormatInterface.php
+++ b/lib/Format/FormatInterface.php
@@ -8,6 +8,7 @@
  */
 namespace FriendsOfRedaxo\addon\MediapoolExif\Format;
 
+use FriendsOfRedaxo\addon\MediapoolExif\Enum\Format;
 use FriendsOfRedaxo\addon\MediapoolExif\Exception\InvalidFormatExcption;
 use FriendsOfRedaxo\addon\MediapoolExif\Format\FormatInterface;
 
@@ -22,20 +23,20 @@ abstract class FormatInterface
 	 * Exif-Daten
 	 * @var array
 	 */
-	protected /* array */ $data;
+	protected array $data;
 
 	/**
 	 * Formatierung
-	 * @var string
+	 * @var Format|null
 	 */
-	protected /* string */ $format;
+	protected ?Format $format;
 
 	/**
 	 * Konstruktor
 	 * @param array $data
-	 * @param string $format
+	 * @param Format|null $format
 	 */
-	public function __construct(array $data, string /*\FriendsOfRedaxo\addon\MediapoolExif\Enum\Format*/ $format = null)
+	public function __construct(array $data, ?Format $format = null)
 	{
 		$this->data = $data;
 		$this->format = $format;
@@ -67,11 +68,11 @@ abstract class FormatInterface
 	 *
 	 * @param string $data exif-Daten-Array
 	 * @param string $type KlasseName des Formatters
-	 * @param string $format Format-Parameter
+	 * @param Format|null $format Format-Parameter
 	 * @return \FriendsOfRedaxo\addon\MediapoolExif\Format\className
 	 * @throws InvalidFormatExcption
 	 */
-	public static function get($data, $type, /*\FriendsOfRedaxo\addon\MediapoolExif\Enum\Format*/ $format = null): FormatInterface
+	public static function get($data, $type, ?Format $format = null): FormatInterface
 	{
 		$className = __NAMESPACE__.'\\'.ucfirst($type);
 		if (class_exists($className)) {
@@ -90,7 +91,7 @@ abstract class FormatInterface
 	 *
 	 * Die Rückgabe kann bei einzelwerten ein string, sont ein array sein.
 	 *
-	 * @return mixed
+	 * @return string|array
 	 */
-	abstract public function format();
+	abstract public function format(): string|array;
 }

--- a/lib/Format/FormatInterface.php
+++ b/lib/Format/FormatInterface.php
@@ -67,13 +67,12 @@ abstract class FormatInterface
 	 * <ul>
 	 *
 	 * @param string $data exif-Daten-Array
-	 * @param string $type KlasseName des Formatters
 	 * @param Format|null $format Format-Parameter
 	 * @param string $className Formatter Namespace
 	 * @return \FriendsOfRedaxo\addon\MediapoolExif\Format\className
 	 * @throws InvalidFormatExcption
 	 */
-	public static function get($data, ?Format $format = null, ?string $className = null): FormatInterface
+	public static function get($data, ?string $className = null, ?Format $format = null): FormatInterface
 	{
 		if (class_exists($className)) {
 			$object = new $className($data, $format);

--- a/lib/Format/Geo.php
+++ b/lib/Format/Geo.php
@@ -15,8 +15,7 @@ use Exception;
  *
  * @author akrys
  */
-class Geo
-	extends FormatInterface
+class Geo extends FormatInterface
 {
 
 	/**
@@ -24,7 +23,7 @@ class Geo
 	 * @return array
 	 * @throws Exception
 	 */
-	public function format()
+	public function format(): array
 	{
 		if (
 			!isset($this->data['GPSLatitude']) ||

--- a/lib/MediapoolExif.php
+++ b/lib/MediapoolExif.php
@@ -21,7 +21,7 @@ class MediapoolExif
 	 * Field mapping
 	 * @var array
 	 */
-	protected static $fields = [
+	protected static array $fields = [
 		'author' => ['Artist', 'AuthorByLine', 'CaptionWriter'],
 		'copyright' => ['Copyright', 'Artist', 'AuthorByLine', 'CaptionWriter'],
 		'orientation' => 'Orientation',
@@ -38,7 +38,7 @@ class MediapoolExif
 	 * Upload processing
 	 * @param rex_extension_point $ep
 	 */
-	public static function processUploadedMedia(rex_extension_point $ep)
+	public static function processUploadedMedia(rex_extension_point $ep): void
 	{
 		$oldMedia = rex_media::get($ep->getParam('filename'));
 		if ($data = static::getDataByFilename($ep->getParam('filename'))) {
@@ -52,7 +52,9 @@ class MediapoolExif
 
 				// check for category?!
 				if (isset($data['categories'])) {
-					$qry = "SELECT `id` FROM `".rex::getTablePrefix()."media_category` WHERE `name` IN ('".join("', '", $data['categories'])."') ORDER BY FIELD (`name`, '".join("', '", $data['categories'])."') LIMIT 1";
+					$qry = "SELECT `id` FROM `".rex::getTablePrefix()."media_category` WHERE `name` IN ('".join(
+							"', '", $data['categories']
+						)."') ORDER BY FIELD (`name`, '".join("', '", $data['categories'])."') LIMIT 1";
 					$sql->setQuery($qry);
 					if ($tmp_result = $sql->getArray()) {
 						$data['category_id'] = $tmp_result[0]['id'];
@@ -121,7 +123,7 @@ class MediapoolExif
 	{
 		$newArray = json_decode($new, true);
 		$oldArray = [];
-		if($old !== null) {
+		if ($old !== null) {
 			$oldArray = json_decode($old, true);
 		}
 
@@ -142,9 +144,9 @@ class MediapoolExif
 	/**
 	 * Daten au der Datei holen
 	 * @param string $filename
-	 * @return array|null
+	 * @return array
 	 */
-	public static function getDataByFilename(string $filename)
+	public static function getDataByFilename(string $filename): array
 	{
 		if ($media = rex_media::get($filename)) {
 			if ($media->fileExists()) {
@@ -152,7 +154,7 @@ class MediapoolExif
 			}
 		}
 
-		return null;
+		return [];
 	}
 
 	/**
@@ -298,9 +300,9 @@ class MediapoolExif
 	/**
 	 * IPTC-Daten holen
 	 * @param rex_media $media
-	 * @return type
+	 * @return array
 	 */
-	protected static function getIptcData(rex_media $media)
+	protected static function getIptcData(rex_media $media): array
 	{
 		$return = [];
 

--- a/lib/MediapoolExif.php
+++ b/lib/MediapoolExif.php
@@ -4,6 +4,7 @@ namespace FriendsOfRedaxo\addon\MediapoolExif;
 
 use Exception;
 use FriendsOfRedaxo\addon\MediapoolExif\Format\FormatInterface;
+use FriendsOfRedaxo\addon\MediapoolExif\Format\Geo;
 use rex;
 use rex_extension_point;
 use rex_fragment;
@@ -255,7 +256,7 @@ class MediapoolExif
 				}
 
 				try {
-					$coordinates = FormatInterface::get($exif, 'Geo')->format();
+					$coordinates = FormatInterface::get($exif, Geo::class)->format();
 					$exif['GPSCoordinatesLat'] = $coordinates['lat'];
 					$exif['GPSCoordinatesLong'] = $coordinates['long'];
 				} catch (Exception $e) {

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: mediapool_exif
-version: '2.1.2'
+version: '3.0'
 author: 'FriendsOfREDAXO'
 supportpage: https://github.com/FriendsOfREDAXO/mediapool_exif
 

--- a/package.yml
+++ b/package.yml
@@ -9,9 +9,9 @@ console_commands:
 
 requires:
     packages:
-        mediapool: '>=2.13.0'
-        metainfo: '>=2.10.0'
-    redaxo: ^5.15.0
+        mediapool: '>=2.3.0'
+        metainfo: '>=2.7.1'
+    redaxo: ^5.2.0
     php:
         version: '>=8.1'
         extensions: [exif]

--- a/package.yml
+++ b/package.yml
@@ -9,9 +9,9 @@ console_commands:
 
 requires:
     packages:
-        mediapool: '>=2.3.0'
-        metainfo: '>=2.7.1'
-    redaxo: ^5.2.0
+        mediapool: '>=2.13.0'
+        metainfo: '>=2.10.0'
+    redaxo: ^5.15.0
     php:
-        version: '>=7.1'
+        version: '>=8.1'
         extensions: [exif]


### PR DESCRIPTION
Umstellung von PHP 7.1 auf PHP 8.1

- Type-Hints konkretisieren (die mit PHP7.1 noch nicht gingen)
- Umstellung von Klassenkonstanten zu `enums`
- weitere kleinere Aufräum-Arbeiten 