### PR TITLE
Bugfix/Aufräum-Release 3.2

### DIFF
--- a/lib/ExifData.php
+++ b/lib/ExifData.php
@@ -97,18 +97,16 @@ class ExifData
 	/**
 	 * Formatierungsalgorithmus anstoßen
 	 * @param string|FormatterInterface $objectParam
-	 * @param Format $format
+	 * @param ?Format $format
 	 * @return mixed
 	 */
 	public function format(
 		string|FormatterInterface $objectParam,
-		/** @deprecated since version 3.1 */ Format $format = Format::READABLE
+		/** @deprecated since version 3.1 */ ?Format $format = null
 	): mixed {
 		try {
-			/** @var FormatterInterface $object */
-			$object = null;
 			/** @var string $className */
-			$className = null;
+			$className = '';
 
 			if (is_object($objectParam)) {
 				$object = $objectParam;
@@ -140,13 +138,19 @@ class ExifData
 			// @codeCoverageIgnoreStart
 			// deprected
 			if (isset(class_parents($className)[FormatInterface::class])) {
+				if ($format === null) {
+					$format = Format::READABLE;
+				}
 				return FormatInterface::get($this->exif, $className, $format)->format();
 			}
 			// @codeCoverageIgnoreEnd
 
+			// @codeCoverageIgnoreStart
+			// deprected
 			if (isset(class_parents($className)[FormatBase::class])) {
 				return FormatBase::get($this->exif, $className)->format();
 			}
+			// @codeCoverageIgnoreEnd
 
 			if (isset(class_implements($className)[FormatterInterface::class])) {
 				$object = new $className();

--- a/lib/Format/Camera.php
+++ b/lib/Format/Camera.php
@@ -17,6 +17,7 @@ use FriendsOfRedaxo\MediapoolExif\Format\Camera\Length;
  * Description of Camera
  *
  * @author akrys
+ * @deprecated use \FriendsOfRedaxo\MediapoolExif\Formatter\Geo instead
  */
 class Camera extends FormatBase
 {
@@ -28,17 +29,10 @@ class Camera extends FormatBase
 	 */
 	public function format(): array
 	{
-		if (!isset($this->data['Make']) && !isset($this->data['Model'])) {
-			throw new Exception('No camera data found');
-		}
+		$msg = "Deprecated class use \FriendsOfRedaxo\MediapoolExif\Formatter\Geo instead";
+		user_error($msg, E_USER_DEPRECATED);
 
-		return [
-			'make' => $this->data['Make'],
-			'model' => $this->data['Model'],
-			'iso' => (new Iso($this->data))->format(),
-			'aperture' => (new Aperture($this->data))->format(),
-			'exposure' => (new Exposure($this->data))->format(),
-			'length' => (new Length($this->data))->format(),
-		];
+		$formatter = new \FriendsOfRedaxo\MediapoolExif\Formatter\Camera();
+		return $formatter->format($this->data);
 	}
 }

--- a/lib/Format/Camera/Aperture.php
+++ b/lib/Format/Camera/Aperture.php
@@ -14,6 +14,7 @@ use FriendsOfRedaxo\MediapoolExif\Format\FormatBase;
  * Description of Aperture
  *
  * @author akrys
+ * @deprecated use \FriendsOfRedaxo\MediapoolExif\Formatter\Camera\Aperture
  */
 class Aperture extends FormatBase
 {
@@ -25,11 +26,10 @@ class Aperture extends FormatBase
 	 */
 	public function format(): string
 	{
-		if (!isset($this->data['FNumber'])) {
-			throw new Exception('No aperture found');
-		}
+		$msg = "Deprecated class use \FriendsOfRedaxo\MediapoolExif\Formatter\Camera\Aperture instead";
+		user_error($msg, E_USER_DEPRECATED);
 
-		$data = explode('/', $this->data['FNumber']);
-		return 'f/'.number_format((float) $data[0] / (float) $data[1], 1);
+		$formatter = new \FriendsOfRedaxo\MediapoolExif\Formatter\Camera\Aperture();
+		return $formatter->format($this->data);
 	}
 }

--- a/lib/Format/Camera/Exposure.php
+++ b/lib/Format/Camera/Exposure.php
@@ -14,6 +14,7 @@ use FriendsOfRedaxo\MediapoolExif\Format\FormatBase;
  * Description of Exposure
  *
  * @author akrys
+ * @deprecated use \FriendsOfRedaxo\MediapoolExif\Formatter\Camera\Exposure instead
  */
 class Exposure extends FormatBase
 {
@@ -25,14 +26,10 @@ class Exposure extends FormatBase
 	 */
 	public function format(): string
 	{
-		if (!isset($this->data['ExposureTime'])) {
-			throw new Exception('No exposure time found');
-		}
+		$msg = "Deprecated class use \FriendsOfRedaxo\MediapoolExif\Formatter\Camera\Exposure instead";
+		user_error($msg, E_USER_DEPRECATED);
 
-		$data = explode('/', $this->data['ExposureTime']);
-		if ($data[0] !== '1' || ($data[0] === '1' && $data[1] < 3)) {
-			return preg_replace('/,0$/', '', number_format((int)$data[0] / (int)$data[1], 1, ',', '.')).' s';
-		}
-		return $data[0].'/'.$data[1].' s';
+		$formatter = new \FriendsOfRedaxo\MediapoolExif\Formatter\Camera\Exposure();
+		return $formatter->format($this->data);
 	}
 }

--- a/lib/Format/Camera/Iso.php
+++ b/lib/Format/Camera/Iso.php
@@ -14,6 +14,7 @@ use FriendsOfRedaxo\MediapoolExif\Format\FormatBase;
  * Description of Iso
  *
  * @author akrys
+ * @deprecated use \FriendsOfRedaxo\MediapoolExif\Formatter\Camera\Iso instead
  */
 class Iso extends FormatBase
 {
@@ -25,10 +26,10 @@ class Iso extends FormatBase
 	 */
 	public function format(): string
 	{
-		if (!isset($this->data['ISOSpeedRatings'])) {
-			throw new Exception('No iso setting found');
-		}
+		$msg = "Deprecated class use \FriendsOfRedaxo\MediapoolExif\Formatter\Camera\Iso instead";
+		user_error($msg, E_USER_DEPRECATED);
 
-		return $this->data['ISOSpeedRatings'];
+		$formatter = new \FriendsOfRedaxo\MediapoolExif\Formatter\Camera\Iso();
+		return $formatter->format($this->data);
 	}
 }

--- a/lib/Format/Camera/Length.php
+++ b/lib/Format/Camera/Length.php
@@ -20,6 +20,7 @@ use FriendsOfRedaxo\MediapoolExif\Format\FormatBase;
  * Description of Length
  *
  * @author akrys
+ * @deprecated use \FriendsOfRedaxo\MediapoolExif\Formatter\Camera\Length instead
  */
 class Length extends FormatBase
 {
@@ -31,13 +32,10 @@ class Length extends FormatBase
 	 */
 	public function format(): string
 	{
-		if (!isset($this->data['FocalLength'])) {
-			throw new Exception('No focial length found');
-		}
+		$msg = "Deprecated class use \FriendsOfRedaxo\MediapoolExif\Formatter\Camera\Length instead";
+		user_error($msg, E_USER_DEPRECATED);
 
-		$data = explode('/', $this->data['FocalLength']);
-		$value = (float) $data[0] / (float) $data[1];
-
-		return $value.' mm';
+		$formatter = new \FriendsOfRedaxo\MediapoolExif\Formatter\Camera\Length();
+		return $formatter->format($this->data);
 	}
 }

--- a/lib/Format/FormatBase.php
+++ b/lib/Format/FormatBase.php
@@ -14,6 +14,7 @@ use FriendsOfRedaxo\MediapoolExif\Exception\InvalidClassException;
  * Description of FormatBase
  *
  * @author akrys
+ * @deprecated Statt der Format-Klassen sollten Klassen mit Formatter-Interfaces verwendet werden.
  */
 abstract class FormatBase
 {
@@ -45,6 +46,7 @@ abstract class FormatBase
 	 * @param array<string, mixed> $data exif-Daten-Array
 	 * @param string $className Formatter Namespace
 	 * @throws InvalidClassException
+	 * @deprecated
 	 */
 	public static function get(
 		$data,

--- a/lib/Format/Geo.php
+++ b/lib/Format/Geo.php
@@ -5,6 +5,7 @@
  *
  * @author        akrys
  */
+
 namespace FriendsOfRedaxo\MediapoolExif\Format;
 
 use Exception;
@@ -13,6 +14,7 @@ use Exception;
  * Description of Geo
  *
  * @author akrys
+ * @deprecated use \FriendsOfRedaxo\MediapoolExif\Formatter\Geo instead
  */
 class Geo extends FormatBase
 {
@@ -24,49 +26,10 @@ class Geo extends FormatBase
 	 */
 	public function format(): array
 	{
-		if (!isset($this->data['GPSLatitude']) ||
-			!isset($this->data['GPSLatitudeRef']) ||
-			!isset($this->data['GPSLongitude']) ||
-			!isset($this->data['GPSLongitudeRef'])) {
-			throw new Exception('GPS not found');
-		}
+		$msg = "Deprecated class use \FriendsOfRedaxo\MediapoolExif\Formatter\Geo instead";
+		user_error($msg, E_USER_DEPRECATED);
 
-		$GPSLatitude = $this->data['GPSLatitude'];
-		$GPSLatitude_Ref = $this->data['GPSLatitudeRef'];
-		$GPSLongitude = $this->data['GPSLongitude'];
-		$GPSLongitude_Ref = $this->data['GPSLongitudeRef'];
-
-		$GPSLatfaktor = 1; //N
-		if ($GPSLatitude_Ref == 'S') {
-			$GPSLatfaktor = -1;
-		}
-
-		$GPSLongfaktor = 1; //E
-		if ($GPSLongitude_Ref == 'W') {
-			$GPSLongfaktor = -1;
-		}
-
-		$GPSLatitude_h = explode("/", $GPSLatitude[0]);
-		$GPSLatitude_m = explode("/", $GPSLatitude[1]);
-		$GPSLatitude_s = explode("/", $GPSLatitude[2]);
-
-		$GPSLat_h = (float) $GPSLatitude_h[0] / (float) $GPSLatitude_h[1];
-		$GPSLat_m = (float) $GPSLatitude_m[0] / (float) $GPSLatitude_m[1];
-		$GPSLat_s = (float) $GPSLatitude_s[0] / (float) $GPSLatitude_s[1];
-
-		$GPSLatGrad = $GPSLatfaktor * ($GPSLat_h + ($GPSLat_m + ($GPSLat_s / 60)) / 60);
-
-		$GPSLongitude_h = explode("/", $GPSLongitude[0]);
-		$GPSLongitude_m = explode("/", $GPSLongitude[1]);
-		$GPSLongitude_s = explode("/", $GPSLongitude[2]);
-		$GPSLong_h = (float) $GPSLongitude_h[0] / (float) $GPSLongitude_h[1];
-		$GPSLong_m = (float) $GPSLongitude_m[0] / (float) $GPSLongitude_m[1];
-		$GPSLong_s = (float) $GPSLongitude_s[0] / (float) $GPSLongitude_s[1];
-		$GPSLongGrad = $GPSLongfaktor * ($GPSLong_h + ($GPSLong_m + ($GPSLong_s / 60)) / 60);
-
-		return [
-			'lat' => number_format($GPSLatGrad, 6, '.', ''),
-			'long' => number_format($GPSLongGrad, 6, '.', ''),
-		];
+		$formatter = new \FriendsOfRedaxo\MediapoolExif\Formatter\Geo();
+		return $formatter->format($this->data);
 	}
 }

--- a/lib/Formatter/Camera.php
+++ b/lib/Formatter/Camera.php
@@ -8,10 +8,10 @@
 namespace FriendsOfRedaxo\MediapoolExif\Formatter;
 
 use Exception;
-use FriendsOfRedaxo\MediapoolExif\Format\Camera\Aperture;
-use FriendsOfRedaxo\MediapoolExif\Format\Camera\Exposure;
-use FriendsOfRedaxo\MediapoolExif\Format\Camera\Iso;
-use FriendsOfRedaxo\MediapoolExif\Format\Camera\Length;
+use FriendsOfRedaxo\MediapoolExif\Formatter\Camera\Aperture;
+use FriendsOfRedaxo\MediapoolExif\Formatter\Camera\Exposure;
+use FriendsOfRedaxo\MediapoolExif\Formatter\Camera\Iso;
+use FriendsOfRedaxo\MediapoolExif\Formatter\Camera\Length;
 use FriendsOfRedaxo\MediapoolExif\Formatter\Interface\ArrayFormatterInterface;
 
 /**
@@ -24,23 +24,23 @@ class Camera implements ArrayFormatterInterface
 
 	/**
 	 * Daten formatieren
-	 * @param array<string, mixed> $data
+	 * @param array<string, mixed> $exifData
 	 * @return array<string, mixed>
 	 * @throws Exception
 	 */
-	public function format(array $data): array
+	public function format(array $exifData): array
 	{
-		if (!isset($data['Make']) && !isset($data['Model'])) {
+		if (!isset($exifData['Make']) && !isset($exifData['Model'])) {
 			throw new Exception('No camera data found');
 		}
 
 		return [
-			'make' => $data['Make'],
-			'model' => $data['Model'],
-			'iso' => (new Iso($data))->format(),
-			'aperture' => (new Aperture($data))->format(),
-			'exposure' => (new Exposure($data))->format(),
-			'length' => (new Length($data))->format(),
+			'make' => $exifData['Make'],
+			'model' => $exifData['Model'],
+			'iso' => (new Iso())->format($exifData),
+			'aperture' => (new Aperture())->format($exifData),
+			'exposure' => (new Exposure())->format($exifData),
+			'length' => (new Length())->format($exifData),
 		];
 	}
 }

--- a/lib/Formatter/Camera/Aperture.php
+++ b/lib/Formatter/Camera/Aperture.php
@@ -5,6 +5,7 @@
  *
  * @author        akrys
  */
+
 namespace FriendsOfRedaxo\MediapoolExif\Formatter\Camera;
 
 use Exception;
@@ -19,18 +20,32 @@ class Aperture implements StandardFormatterInterface
 {
 
 	/**
-	 * Daten formatieren
-	 * @param array<string, mixed> $exif
+	 * Basis-Wert ermitteln.
+	 *
+	 * Kann in einem abgeleiteten Formatter verwendet werden um den Basis-Wert zu bekommen
+	 *
+	 * @param array<string, mixed> $exifData
 	 * @return string
 	 * @throws Exception
 	 */
-	public function format(array $exif): string
+	public function getValue(array $exifData): string
 	{
-		if (!isset($exif['FNumber'])) {
+		if (!isset($exifData['FNumber'])) {
 			throw new Exception('No aperture found');
 		}
 
-		$data = explode('/', $exif['FNumber']);
-		return 'f/'.number_format((float) $data[0] / (float) $data[1], 1);
+		$data = explode('/', $exifData['FNumber']);
+		return number_format((float)$data[0] / (float)$data[1], 1);
+	}
+
+	/**
+	 * Daten formatieren
+	 * @param array<string, mixed> $exifData
+	 * @return string
+	 * @throws Exception
+	 */
+	public function format(array $exifData): string
+	{
+		return 'f/' . $this->getValue($exifData);
 	}
 }

--- a/lib/Formatter/Camera/Exposure.php
+++ b/lib/Formatter/Camera/Exposure.php
@@ -5,6 +5,7 @@
  *
  * @author        akrys
  */
+
 namespace FriendsOfRedaxo\MediapoolExif\Formatter\Camera;
 
 use Exception;
@@ -19,21 +20,51 @@ class Exposure implements StandardFormatterInterface
 {
 
 	/**
-	 * Daten formatieren
-	 * @param array<string, mixed> $exif
+	 * Basis-Wert ermitteln.
+	 *
+	 * Kann in einem abgeleiteten Formatter verwendet werden um den Basis-Wert zu bekommen
+	 *
+	 * @param array<string, mixed> $exifData
 	 * @return string
 	 * @throws Exception
 	 */
-	public function format(array $exif): string
+	public function getValue(array $exifData): string
 	{
-		if (!isset($exif['ExposureTime'])) {
+		if (!isset($exifData['ExposureTime'])) {
 			throw new Exception('No exposure time found');
 		}
 
-		$data = explode('/', $exif['ExposureTime']);
-		if ($data[0] !== '1' || ($data[0] === '1' && $data[1] < 3)) {
-			return preg_replace('/,0$/', '', number_format((int)$data[0] / (int)$data[1], 1, ',', '.')).' s';
+		$data = explode('/', $exifData['ExposureTime']);
+		if ($this->useNumericalSeconds($data)) {
+			$value = number_format((int)$data[0] / (int)$data[1], 1, ',', '.');
+			return preg_replace('/,0$/', '', $value) ?? '';
 		}
-		return $data[0].'/'.$data[1].' s';
+		return $data[0] . '/' . $data[1];
+	}
+
+	/**
+	 * Daten formatieren
+	 * @param array<string, mixed> $exifData
+	 * @return string
+	 * @throws Exception
+	 */
+	public function format(array $exifData): string
+	{
+		return $this->getValue($exifData) . ' s';
+	}
+
+	/**
+	 * @param list<string> $data
+	 * @return bool
+	 */
+	private function useNumericalSeconds(array $data): bool
+	{
+		if ($data[0] !== '1') {
+			return true;
+		}
+		if ($data[1] < 3) {
+			return true;
+		}
+		return false;
 	}
 }

--- a/lib/Formatter/Camera/Iso.php
+++ b/lib/Formatter/Camera/Iso.php
@@ -20,16 +20,16 @@ class Iso implements StandardFormatterInterface
 
 	/**
 	 * Daten formatieren
-	 * @param array<string, mixed> $data
+	 * @param array<string, mixed> $exifData
 	 * @return string
 	 * @throws Exception
 	 */
-	public function format(array $data): string
+	public function format(array $exifData): string
 	{
-		if (!isset($data['ISOSpeedRatings'])) {
+		if (!isset($exifData['ISOSpeedRatings'])) {
 			throw new Exception('No iso setting found');
 		}
 
-		return $data['ISOSpeedRatings'];
+		return $exifData['ISOSpeedRatings'];
 	}
 }

--- a/lib/Formatter/Camera/Length.php
+++ b/lib/Formatter/Camera/Length.php
@@ -19,20 +19,32 @@ class Length implements StandardFormatterInterface
 {
 
 	/**
-	 * Daten formatieren
-	 * @param array<string, mixed> $data
+	 * Basis-Wert ermitteln.
+	 *
+	 * Kann in einem abgeleiteten Formatter verwendet werden um den Basis-Wert zu bekommen
+	 *
+	 * @param array<string, mixed> $exifData
 	 * @return string
-	 * @throws Exception
 	 */
-	public function format(array $data): string
+	public function getValue(array $exifData): string
 	{
-		if (!isset($data['FocalLength'])) {
+		if (!isset($exifData['FocalLength'])) {
 			throw new Exception('No focial length found');
 		}
 
-		$data = explode('/', $data['FocalLength']);
-		$value = (float) $data[0] / (float) $data[1];
+		$exifData = explode('/', $exifData['FocalLength']);
+		$value = (float) $exifData[0] / (float) $exifData[1];
+		return (string) $value;
+	}
 
-		return $value.' mm';
+	/**
+	 * Daten formatieren
+	 * @param array<string, mixed> $exifData
+	 * @return string
+	 * @throws Exception
+	 */
+	public function format(array $exifData): string
+	{
+		return $this->getValue($exifData).' mm';
 	}
 }

--- a/lib/Formatter/Geo.php
+++ b/lib/Formatter/Geo.php
@@ -5,66 +5,46 @@
  *
  * @author        akrys
  */
+
 namespace FriendsOfRedaxo\MediapoolExif\Formatter;
 
 use Exception;
-use FriendsOfRedaxo\MediapoolExif\Formatter\Interface\ArrayFormatterInterface;
 
 /**
  * Description of Geo
  *
  * @author akrys
  */
-class Geo implements ArrayFormatterInterface
+class Geo extends GeoBase
 {
 
 	/**
 	 * Formatierung der Daten
-	 * @param array<string, mixed> $data
+	 * @param array<string, mixed> $exifData
 	 * @return array<string, mixed>
 	 * @throws Exception
 	 */
-	public function format(array $data): array
+	public function format(array $exifData): array
 	{
-		if (!isset($data['GPSLatitude']) ||
-			!isset($data['GPSLatitudeRef']) ||
-			!isset($data['GPSLongitude']) ||
-			!isset($data['GPSLongitudeRef'])) {
+		if (!$this->hasGeoData($exifData)) {
 			throw new Exception('GPS not found');
 		}
 
-		$GPSLatitude = $data['GPSLatitude'];
-		$GPSLatitude_Ref = $data['GPSLatitudeRef'];
-		$GPSLongitude = $data['GPSLongitude'];
-		$GPSLongitude_Ref = $data['GPSLongitudeRef'];
+		$lat = $this->getLat($exifData);
+		$long = $this->getLong($exifData);
 
 		$GPSLatfaktor = 1; //N
-		if ($GPSLatitude_Ref == 'S') {
+		if ($lat->ref == 'S') {
 			$GPSLatfaktor = -1;
 		}
 
 		$GPSLongfaktor = 1; //E
-		if ($GPSLongitude_Ref == 'W') {
+		if ($long->ref == 'W') {
 			$GPSLongfaktor = -1;
 		}
 
-		$GPSLatitude_h = explode("/", $GPSLatitude[0]);
-		$GPSLatitude_m = explode("/", $GPSLatitude[1]);
-		$GPSLatitude_s = explode("/", $GPSLatitude[2]);
-
-		$GPSLat_h = (float) $GPSLatitude_h[0] / (float) $GPSLatitude_h[1];
-		$GPSLat_m = (float) $GPSLatitude_m[0] / (float) $GPSLatitude_m[1];
-		$GPSLat_s = (float) $GPSLatitude_s[0] / (float) $GPSLatitude_s[1];
-
-		$GPSLatGrad = $GPSLatfaktor * ($GPSLat_h + ($GPSLat_m + ($GPSLat_s / 60)) / 60);
-
-		$GPSLongitude_h = explode("/", $GPSLongitude[0]);
-		$GPSLongitude_m = explode("/", $GPSLongitude[1]);
-		$GPSLongitude_s = explode("/", $GPSLongitude[2]);
-		$GPSLong_h = (float) $GPSLongitude_h[0] / (float) $GPSLongitude_h[1];
-		$GPSLong_m = (float) $GPSLongitude_m[0] / (float) $GPSLongitude_m[1];
-		$GPSLong_s = (float) $GPSLongitude_s[0] / (float) $GPSLongitude_s[1];
-		$GPSLongGrad = $GPSLongfaktor * ($GPSLong_h + ($GPSLong_m + ($GPSLong_s / 60)) / 60);
+		$GPSLatGrad = $GPSLatfaktor * ($lat->degree + ($lat->minute + ($lat->second/ 60)) / 60);
+		$GPSLongGrad = $GPSLongfaktor * ($long->degree + ($long->minute + ($long->second / 60)) / 60);
 
 		return [
 			'lat' => number_format($GPSLatGrad, 6, '.', ''),

--- a/lib/Formatter/GeoBase.php
+++ b/lib/Formatter/GeoBase.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace FriendsOfRedaxo\MediapoolExif\Formatter;
+
+use FriendsOfRedaxo\MediapoolExif\Formatter\Interface\ArrayFormatterInterface;
+use FriendsOfRedaxo\MediapoolExif\Model\GeoCoordinate;
+
+abstract class GeoBase implements ArrayFormatterInterface
+{
+
+	/**
+	 * Geo-Daten vorhanden?
+	 *
+	 * @param array<string, mixed> $exifData
+	 * @return bool
+	 */
+	protected function hasGeoData(array $exifData)
+	{
+		if (!isset($exifData['GPSLatitude']) ||
+			!isset($exifData['GPSLatitudeRef']) ||
+			!isset($exifData['GPSLongitude']) ||
+			!isset($exifData['GPSLongitudeRef'])) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Nord/Süd-Grad-Wert holen
+	 *
+	 * @param array<string, mixed> $exifData
+	 * @return GeoCoordinate
+	 */
+	public function getLat(array $exifData): GeoCoordinate
+	{
+		return $this->getDegreeValue($exifData['GPSLatitude'], $exifData['GPSLatitudeRef']);
+	}
+
+	/**
+	 * Ost/West-Grad-Wert holen
+	 *
+	 * @param array<string, mixed> $exifData
+	 * @return GeoCoordinate
+	 */
+
+	public function getLong(array $exifData): GeoCoordinate
+	{
+		return $this->getDegreeValue($exifData['GPSLongitude'], $exifData['GPSLongitudeRef']);
+	}
+
+	/**
+	 * Basis-Berechnung durchführen
+	 *
+	 * @param array<int, string>$value
+	 * @param string $ref
+	 * @return GeoCoordinate
+	 */
+	private function getDegreeValue(array $value, string $ref): GeoCoordinate
+	{
+		$h = explode("/", $value[0]);
+		$m = explode("/", $value[1]);
+		$s = explode("/", $value[2]);
+
+		return new GeoCoordinate(
+			degree: (float)$h[0] / (float)$h[1],
+			minute: (float)$m[0] / (float)$m[1],
+			second: (float)$s[0] / (float)$s[1],
+			ref: $ref
+		);
+	}
+
+}

--- a/lib/Formatter/GeoDegree.php
+++ b/lib/Formatter/GeoDegree.php
@@ -5,10 +5,11 @@
  *
  * @author        akrys
  */
+
 namespace FriendsOfRedaxo\MediapoolExif\Formatter;
 
 use Exception;
-use FriendsOfRedaxo\MediapoolExif\Formatter\Interface\ArrayFormatterInterface;
+
 
 /**
  * Description of Geo
@@ -26,7 +27,7 @@ use FriendsOfRedaxo\MediapoolExif\Formatter\Interface\ArrayFormatterInterface;
  *
  * @author akrys
  */
-class GeoDegree implements ArrayFormatterInterface
+class GeoDegree extends GeoBase
 {
 
 	/**
@@ -34,43 +35,18 @@ class GeoDegree implements ArrayFormatterInterface
 	 * @return array<string, mixed>
 	 * @throws Exception
 	 */
-	public function format(array $data): array
+	public function format(array $exifData): array
 	{
-		if (!isset($data['GPSLatitude']) ||
-			!isset($data['GPSLatitudeRef']) ||
-			!isset($data['GPSLongitude']) ||
-			!isset($data['GPSLongitudeRef'])) {
+		if (!$this->hasGeoData($exifData)) {
 			throw new Exception('GPS not found');
 		}
 
-		$GPSLatitude = $data['GPSLatitude'];
-		$GPSLatitude_Ref = $data['GPSLatitudeRef'];
-		$GPSLongitude = $data['GPSLongitude'];
-		$GPSLongitude_Ref = $data['GPSLongitudeRef'];
-
-		$latSuffix = $this->getLatSuffix($GPSLatitude_Ref);
-
-		$longSuffix = $this->getLongSuffix($GPSLongitude_Ref);
-
-		$GPSLatitude_h = explode("/", $GPSLatitude[0]);
-		$GPSLatitude_m = explode("/", $GPSLatitude[1]);
-		$GPSLatitude_s = explode("/", $GPSLatitude[2]);
-
-		$GPSLat_h = (float) $GPSLatitude_h[0] / (float) $GPSLatitude_h[1];
-		$GPSLat_m = (float) $GPSLatitude_m[0] / (float) $GPSLatitude_m[1];
-		$GPSLat_s = (float) $GPSLatitude_s[0] / (float) $GPSLatitude_s[1];
-
-		$GPSLongitude_h = explode("/", $GPSLongitude[0]);
-		$GPSLongitude_m = explode("/", $GPSLongitude[1]);
-		$GPSLongitude_s = explode("/", $GPSLongitude[2]);
-
-		$GPSLong_h = (float) $GPSLongitude_h[0] / (float) $GPSLongitude_h[1];
-		$GPSLong_m = (float) $GPSLongitude_m[0] / (float) $GPSLongitude_m[1];
-		$GPSLong_s = (float) $GPSLongitude_s[0] / (float) $GPSLongitude_s[1];
+		$lat = $this->getLat($exifData);
+		$long = $this->getLong($exifData);
 
 		return [
-			'lat' => $GPSLat_h.'° '.$GPSLat_m."' ".$GPSLat_s.'" '.$latSuffix,
-			'long' => $GPSLong_h.'° '.$GPSLong_m."' ".$GPSLong_s.'" '.$longSuffix,
+			'lat' => $lat->degree . '° ' . $lat->minute . "' " . $lat->second . '" ' . $this->getLatSuffix($lat->ref),
+			'long' => $long->degree . '° ' . $long->minute . "' " . $long->second . '" ' . $this->getLongSuffix($long->ref),
 		];
 	}
 

--- a/lib/MediapoolExif.php
+++ b/lib/MediapoolExif.php
@@ -4,9 +4,8 @@ namespace FriendsOfRedaxo\MediapoolExif;
 
 use Exception;
 use FriendsOfRedaxo\MediapoolExif\Enum\IptcDefinitions;
-use FriendsOfRedaxo\MediapoolExif\Format\FormatInterface;
-use FriendsOfRedaxo\MediapoolExif\Format\Geo;
 use FriendsOfRedaxo\MediapoolExif\Exception\IptcException;
+use FriendsOfRedaxo\MediapoolExif\Formatter\Geo;
 use rex;
 use rex_extension_point;
 use rex_fragment;
@@ -21,8 +20,8 @@ use function mb_convert_encoding;
 /**
  * @codeCoverageIgnore
  * -> Nur Redaxo=Plattform-Integration
- * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
- * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ * @SuppressWarnings("PHPMD.ExcessiveClassComplexity")
+ * @SuppressWarnings("PHPMD.CouplingBetweenObjects")
  * -> man könnte vllt mal was auslagern
  */
 final class MediapoolExif
@@ -47,12 +46,12 @@ final class MediapoolExif
 	/**
 	 * Upload processing
 	 * @param rex_extension_point<string> $exp
-	 * @SuppressWarnings(PHPMD.ElseExpression)
+	 * @SuppressWarnings("PHPMD.ElseExpression")
 	 * -> zu tief verschachtelt.... vllt. Funktionsauslagerung?
-	 * @SuppressWarnings(PHPMD.IfStatementAssignment)
+	 * @SuppressWarnings("PHPMD.IfStatementAssignment")
 	 * -> bei Datenbankabfragen kaum anders zu machen
-	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
-	 * @SuppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings("PHPMD.CyclomaticComplexity")
+	 * @SuppressWarnings("PHPMD.NPathComplexity")
 	 */
 	public static function processUploadedMedia(rex_extension_point $exp): void
 	{
@@ -182,13 +181,13 @@ final class MediapoolExif
 	 * Daten aus der Datei verarbeiten
 	 * @param rex_media $media
 	 * @param string $key
-	 * @return array<string, mixed>
-	 * @SuppressWarnings(PHPMD.ElseExpression)
+	 * @return mixed
+	 * @SuppressWarnings("PHPMD.ElseExpression")
 	 * -> zu tief verschachtelt.... vllt. Funktionsauslagerung?
-	 * @SuppressWarnings(PHPMD.CyclomaticComplexity)
-	 * @SuppressWarnings(PHPMD.NPathComplexity)
+	 * @SuppressWarnings("PHPMD.CyclomaticComplexity")
+	 * @SuppressWarnings("PHPMD.NPathComplexity")
 	 */
-	public static function getData(rex_media $media, string $key = null): array
+	public static function getData(rex_media $media, string $key = null): mixed
 	{
 		$DATA = array_replace(static::getExifData($media), static::getIptcData($media));
 		$return = [];
@@ -241,7 +240,7 @@ final class MediapoolExif
 			}
 		}
 
-		if (!empty($key) && is_string($key)) {
+		if (!empty($key)) {
 			return isset($return[$key]) ? $return[$key] : null;
 		}
 
@@ -280,7 +279,7 @@ final class MediapoolExif
 				}
 
 				try {
-					$coordinates = FormatInterface::get($exif, Geo::class)->format();
+					$coordinates = (new Geo())->format($exif);
 					$exif['GPSCoordinatesLat'] = $coordinates['lat'] ?? 0;
 					$exif['GPSCoordinatesLong'] = $coordinates['long'] ?? 0;
 				} catch (Exception $e) {

--- a/lib/Model/GeoCoordinate.php
+++ b/lib/Model/GeoCoordinate.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace FriendsOfRedaxo\MediapoolExif\Model;
+
+class GeoCoordinate
+{
+
+	/**
+	 * Abbildung einer Korrdinate
+	 *
+	 * @param float $degree Grad
+	 * @param float $minute Grad-Minuten
+	 * @param float $second Grad-Sekunden
+	 * @param string $ref N/S bzw O/W-Referenz
+	 */
+	public function __construct(
+		public readonly float  $degree,
+		public readonly float  $minute,
+		public readonly float  $second,
+		public readonly string $ref,
+	){
+	}
+}

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: mediapool_exif
-version: '3.1.1'
+version: '3.2'
 author: 'FriendsOfREDAXO'
 supportpage: https://github.com/FriendsOfREDAXO/mediapool_exif
 


### PR DESCRIPTION
Bugfix/Aufräum-Release
- FriendsOfRedaxo\MediapoolExif\MediapoolExif::getData kann auch was anderes als `array` liefern.
Grund: Auswahlmöglichkeit via `$key`-Parameter
- Alle `Format`-Klassen als `deprecated` markieren. In Zukunft gelten nur noch die `Formatter`-Klassen. Die basieren nur noch auf Interfaces, statt Ableitung
- Formatter aufräumen, so dass Code nicht doppelt vorhanden ist. (alte `Format`-Klassen und neue `Formatter`-Klassen)